### PR TITLE
Move to Viper for config management

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,9 +4,10 @@ import (
 	"path"
 	"strings"
 
+	"github.com/layer5io/meshery-adapter-library/adapter"
 	"github.com/layer5io/meshery-adapter-library/common"
 	"github.com/layer5io/meshery-adapter-library/config"
-	configprovider "github.com/layer5io/meshery-adapter-library/config/provider"
+	configprovider "github.com/layer5io/meshkit/config/provider"
 	"github.com/layer5io/meshery-adapter-library/status"
 
 	//	"github.com/layer5io/meshery-adapter-library"
@@ -34,10 +35,9 @@ var (
 	configRootPath = path.Join(utils.GetHome(), ".meshery")
 
 	Config = configprovider.Options{
-		ServerConfig:   ServerConfig,
-		MeshSpec:       MeshSpec,
-		ProviderConfig: ProviderConfig,
-		Operations:     Operations,
+		FilePath: configRootPath,
+		FileName: "app-mesh",
+		FileType: "yaml",
 	}
 
 	// ServerConfig is the configuration for the gRPC server
@@ -75,22 +75,47 @@ var (
 )
 
 // New creates a new config instance
-func New(provider string) (config.Handler, error) {
+func New(provider string) (h config.Handler, err error) {
 	// Config provider
 	switch provider {
 	case configprovider.ViperKey:
-		return configprovider.NewViper(Config)
+		h, err = configprovider.NewViper(Config)
+		if err != nil {
+			return nil, err
+		}
 	case configprovider.InMemKey:
-		return configprovider.NewInMem(Config)
+		h, err = configprovider.NewInMem(Config)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, ErrEmptyConfig
 	}
 
-	return nil, ErrEmptyConfig
+	// Setup server config
+	if err := h.SetObject(adapter.ServerKey, ServerConfig); err != nil {
+		return nil, err
+	}
 
+	// Setup mesh config
+	if err := h.SetObject(adapter.MeshSpecKey, MeshSpec); err != nil {
+		return nil, err
+	}
+
+	// Setup Operations Config
+	if err := h.SetObject(adapter.OperationsKey, Operations); err != nil {
+		return nil, err
+	}
+
+	return h, nil
 }
 
 func NewKubeconfigBuilder(provider string) (config.Handler, error) {
-	opts := configprovider.Options{}
-	opts.ProviderConfig = KubeConfig
+	opts := configprovider.Options{
+		FilePath: configRootPath,
+		FileType: "yaml",
+		FileName: "kubeconfig",
+	}
 
 	// Config provider
 	switch provider {

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 
 	// Initialize application specific configs and dependencies
 	// App and request config
-	cfg, err := config.New(configprovider.InMemKey)
+	cfg, err := config.New(configprovider.ViperKey)
 	if err != nil {
 		log.Error(err)
 		os.Exit(1)


### PR DESCRIPTION
**Description**
Use Viper for management of adapter and kubernetes config like the Istio adapter instead of in-memory

This PR fixes Kubeconfig resetting on adapter startup



**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->