### PR TITLE
App Mesh: Remove arch hardcode and kubeopenapi-jsonschema

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,20 +14,13 @@ COPY main.go main.go
 COPY internal/ internal/
 COPY appmesh/ appmesh/
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags="-w -s -X main.version=$VERSION -X main.gitsha=$GIT_COMMITSHA" -a -o meshery-app-mesh main.go
-
-FROM alpine:3.15 as jsonschema-util
-RUN apk add --no-cache curl
-WORKDIR /
-RUN curl -LO https://github.com/layer5io/kubeopenapi-jsonschema/releases/download/v0.1.2/kubeopenapi-jsonschema
-RUN chmod +x /kubeopenapi-jsonschema
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -ldflags="-w -s -X main.version=$VERSION -X main.gitsha=$GIT_COMMITSHA" -a -o meshery-app-mesh main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/nodejs:16
 WORKDIR /
 ENV DISTRO="debian"
-ENV GOARCH="amd64"
 ENV SERVICE_ADDR="meshery-app-mesh"
 ENV MESHERY_SERVER="http://meshery:9081"
 COPY --from=builder /build/meshery-app-mesh .


### PR DESCRIPTION
**Description**
Removes hardcoding to amd64 arch.
Removes deprecated kubeopenapi-jsonschema

This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->