### PR TITLE
upgrade staticcheck-action to v1.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.19
-      - uses: dominikh/staticcheck-action@v1.2.0
+      - uses: dominikh/staticcheck-action@v1.3.0
         with:
           install-go: false
           version: "2022.1"


### PR DESCRIPTION
This PR fixes https://github.com/meshery/meshery/issues/13041, upgrading `dominikh/staticcheck-action@v1.2.0` to `dominikh/staticcheck-action@v1.3.0`

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.